### PR TITLE
Resolve fraud detection state machine not being triggered issue

### DIFF
--- a/insurance_claim_process_cdk/lambdafn.py
+++ b/insurance_claim_process_cdk/lambdafn.py
@@ -91,7 +91,7 @@ class LambdaStack(NestedStack):
             code=lambda_.InlineCode(handler_code),
             handler="index.lambda_handler",
             timeout=Duration.seconds(300),
-            runtime=lambda_.Runtime.PYTHON_3_13,
+            runtime=lambda_.Runtime.PYTHON_3_11,
             environment={"ENDPOINT_NAME": endpoint_name},
             layers=[pandas_layer_version],
         )

--- a/insurance_claim_process_cdk/stepfunctions/definitions/insuranceclaim-Main_Workflow.json
+++ b/insurance_claim_process_cdk/stepfunctions/definitions/insuranceclaim-Main_Workflow.json
@@ -1,8 +1,13 @@
 {
   "QueryLanguage": "JSONata",
   "Comment": "A description of my state machine",
-  "StartAt": "List Claim Documents",
+  "StartAt": "Wait for Upload Completion",
   "States": {
+    "Wait for Upload Completion": {
+      "Type": "Wait",
+      "Seconds": 10,
+      "Next": "List Claim Documents"
+    },
     "List Claim Documents": {
       "Type": "Task",
       "Arguments": {
@@ -52,31 +57,18 @@
                 "AWS_STEP_FUNCTIONS_STARTED_BY_EXECUTION_ID": "{% $states.context.Execution.Id %}"
               }
             },
-            "Next": "Validate & Transform",
-            "Output": "{% $merge([$states.input, {'documentType':$states.result.Output.documentType}])%}"
-          },
-          "Validate & Transform": {
-            "Type": "Task",
-            "Resource": "arn:aws:states:::states:startExecution.sync:2",
-            "Arguments": {
-              "StateMachineArn": "arn:aws:states:<AWS_REGION>:<AWS_ACCOUNT>:stateMachine:insuranceclaim-Validation-Transform",
-              "Input": {
-                "StatePayload": "{% $states.input%}",
-                "AWS_STEP_FUNCTIONS_STARTED_BY_EXECUTION_ID": "{% $states.context.Execution.Id %}"
-              }
-            },
             "Next": "Is this a picture?",
-            "Output": "{% $states.input %}"
+            "Output": "{% $merge([$states.input, {'documentType':$states.result.Output.documentType}])%}"
           },
           "Is this a picture?": {
             "Type": "Choice",
             "Choices": [
               {
                 "Next": "Fraud Detection- Tampered Image",
-                "Condition": "{% $states.input.documentType='Pictures' %}"
+                "Condition": "{% $states.input.documentType='Disaster Damage Assessment' %}"
               }
             ],
-            "Default": "Insight Generation"
+            "Default": "Done"
           },
           "Fraud Detection- Tampered Image": {
             "Type": "Task",
@@ -85,18 +77,6 @@
               "StateMachineArn": "arn:aws:states:<AWS_REGION>:<AWS_ACCOUNT>:stateMachine:insuranceclaim-FraudDetection",
               "Input": {
                 "StatePayload": "{% $states.input %}",
-                "AWS_STEP_FUNCTIONS_STARTED_BY_EXECUTION_ID": "{% $states.context.Execution.Id %}"
-              }
-            },
-            "Next": "Insight Generation"
-          },
-          "Insight Generation": {
-            "Type": "Task",
-            "Resource": "arn:aws:states:::states:startExecution.sync:2",
-            "Arguments": {
-              "StateMachineArn": "arn:aws:states:<AWS_REGION>:<AWS_ACCOUNT>:stateMachine:insuranceclaim-Validation-Transform",
-              "Input": {
-                "StatePayload": "Hello from Step Functions!",
                 "AWS_STEP_FUNCTIONS_STARTED_BY_EXECUTION_ID": "{% $states.context.Execution.Id %}"
               }
             },


### PR DESCRIPTION
*Issue #, if available:* I found out that 
1. fraud detection state machine is not being triggered because of documentType is not matched 
2. list claim documents causes error because it does not wait until the upload is complete. 
3. Python runtime mismatch for image tampering detection lambda function
4. Validate & Transform and Insight Generation state machines are just placeholders, causing unnecessary delay

*Description of changes:* 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
